### PR TITLE
Fallback to plain text body when JSON parsing fails to be consistent with how `request-promise` worked previously

### DIFF
--- a/lib/fetchApi.js
+++ b/lib/fetchApi.js
@@ -14,7 +14,12 @@ async function fetchApi(resource, options) {
   }
   const raw = await fetchApiRaw(resource, options);
   if (!!raw) {
-    return JSON.parse(raw);
+    try {
+      return JSON.parse(raw);
+    }
+    catch {
+      return raw;
+    }
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "login.dfe.async-retry",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "login.dfe.async-retry",
-      "version": "1.1.0",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "retry": "^0.13.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "login.dfe.async-retry",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Async retry library for NodeJS built on top of retry",
   "main": "lib/index.js",
   "directories": {

--- a/test/fetchApi.test.js
+++ b/test/fetchApi.test.js
@@ -62,4 +62,12 @@ describe('fetchApi(resource, options)', () => {
       status: 'OK',
     });
   });
+
+  it('returns plain text when json parsing of body fails (consistent with how request-promise worked previously)', async () => {
+    fetchApiRaw.mockResolvedValue('Plain text response.');
+
+    const response = await fetchApi('https://localhost/test');
+
+    expect(response).toEqual('Plain text response.');
+  });
 });


### PR DESCRIPTION
Whilst migrating existing services to use `fetchApi` instead of `request-promise` we have encountered a scenario where the existing API call does not return a JSON encoded response yet `json: true` was being provided.

This worked previously because `request` (used by `request-promise`) wraps `JSON.parse` in a try...catch statement which falls back to the plain text body when JSON parsing fails (see: https://github.com/request/request/blob/master/request.js#L1144-L1148).

The use case here is that the request can be JSON encoded whilst the response can be plain text.