### PR TITLE
Include parsed error body in errors (Contributes to DSI-6783)

### DIFF
--- a/lib/FetchApiStatusError.js
+++ b/lib/FetchApiStatusError.js
@@ -1,8 +1,9 @@
 class FetchApiStatusError extends Error {
-  constructor(statusCode) {
+  constructor(statusCode, body) {
     super(`Request failed with status code ${statusCode}`);
     this.name = 'FetchApiStatusError';
     this.statusCode = statusCode;
+    this.error = body;
   }
 }
 

--- a/lib/fetchApiRaw.js
+++ b/lib/fetchApiRaw.js
@@ -1,6 +1,15 @@
 const FetchApiStatusError = require('./FetchApiStatusError');
 const asyncRetry = require('./asyncRetry');
 
+async function parseErrorBody(response) {
+  try {
+    return await response.json();
+  }
+  catch {
+    return undefined;
+  }
+}
+
 async function fetchApiRaw(resource, options) {
   const retryStrategy = options?.retry;
 
@@ -13,7 +22,8 @@ async function fetchApiRaw(resource, options) {
     // The following has been implemented to match how `request-promise`
     // in terms of how errors are thrown with non-2xx status codes.    
     if (response.status < 200 || response.status > 299) {
-      throw new FetchApiStatusError(response.status);
+      const errorBody = await parseErrorBody(response);
+      throw new FetchApiStatusError(response.status, errorBody);
     }
 
     return response;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "login.dfe.async-retry",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "login.dfe.async-retry",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
         "retry": "^0.13.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "login.dfe.async-retry",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Async retry library for NodeJS built on top of retry",
   "main": "lib/index.js",
   "directories": {

--- a/test/fetchApiRaw.test.js
+++ b/test/fetchApiRaw.test.js
@@ -87,4 +87,32 @@ describe('fetchApiRaw(resource, options)', () => {
 
     await expect(act).rejects.toThrow(`Request failed with status code ${statusCode}`);
   });
+
+  it('throws error and includes a parsed error body', async () => {
+    mockedFetch.mockResolvedValue({
+      status: 500,
+      json: async () => ({ "response_code": "FAIL_XYZ" }),
+    });
+
+    const act = async () => {
+      await fetchApiRaw('https://localhost/test');
+    };
+
+    await expect(act).rejects.toHaveProperty('error', {
+      response_code: "FAIL_XYZ",
+    });
+  });
+
+  it('throws error and has no error body when one cannot be parsed', async () => {
+    mockedFetch.mockResolvedValue({
+      status: 500,
+      json: async () => JSON.parse('@'),
+    });
+
+    const act = async () => {
+      await fetchApiRaw('https://localhost/test');
+    };
+
+    await expect(act).rejects.toHaveProperty('error', undefined);
+  });
 });


### PR DESCRIPTION
This change is being made since this behaviour of `request-promise` was being used in a couple of scenarios.